### PR TITLE
Fix for matches being lost near the celestial poles

### DIFF
--- a/AxsUtilities/src/main/scala/org/dirac/axs/FrameFunctions.scala
+++ b/AxsUtilities/src/main/scala/org/dirac/axs/FrameFunctions.scala
@@ -12,8 +12,8 @@ class FrameFunctions {
 }
 
 object FrameFunctions {
-  def calcGnom = (r1: Double, r2: Double, d1: Double, d2: Double) => {
-    val doNotCalc = (Math.abs(r1 - r2) > 1 && Math.abs(r1 - r2 - 360) > 1) || Math.abs(d1 - d2) > 1
+  def calcGnom = (r1: Double, r2: Double, d1: Double, d2: Double, rcd1: Double, rcd2: Double) => {
+    val doNotCalc = (Math.abs(rcd1 - rcd2) > 1 && Math.abs(rcd1 - rcd2 - 360) > 1) || Math.abs(d1 - d2) > 1
     if (doNotCalc) {
       Double.MaxValue
     } else {
@@ -63,7 +63,8 @@ object FrameFunctions {
     if (returnMin) {
       distcolname = "axsdisttemp"
     }
-    val join2 = join.withColumn(distcolname, calcGnomUdf.get(df1("ra"), df2("ra"), df1("dec"), df2("dec"))).
+    val join2 = join.withColumn(distcolname, 
+             calcGnomUdf.get(df1("ra"), df2("ra"), df1("dec"), df2("dec"), df1("racosdec"), df2("racosdec"))).
       withColumn("ratemp", df1("ra")).withColumn("dectemp", df1("dec")).withColumn("racosdectemp", df1("racosdec")).
       withColumn("zonetemp", df1("zone")).drop("zone").drop("ra").drop("dec").drop("racosdec").
       withColumnRenamed("ratemp", "ra").

--- a/AxsUtilities/src/main/scala/org/dirac/axs/FrameFunctions.scala
+++ b/AxsUtilities/src/main/scala/org/dirac/axs/FrameFunctions.scala
@@ -52,10 +52,10 @@ object FrameFunctions {
 
     val join = if (useSMJOptim)
         df1.join(df2, df1("zone") === df2("zone") and 
-                      (abs(df1("ra") - df2("ra"))*cos(radians((df1("dec")+df2("dec")/2))) < r))
+                      (abs(df1("ra") - df2("ra"))*cos(radians((df1("dec")+df2("dec"))/2)) < r))
       else
         df1.join(df2, df1("zone") === df2("zone") and
-                      (abs(df1("ra") - df2("ra"))*cos(radians((df1("dec")+df2("dec")/2))) < r) and
+                      (abs(df1("ra") - df2("ra"))*cos(radians((df1("dec")+df2("dec"))/2)) < r) and
                       (df1("dec") between(df2("dec") - r, df2("dec") + r)))
 
     var distcolname = "axsdist"

--- a/AxsUtilities/src/main/scala/org/dirac/axs/FrameFunctions.scala
+++ b/AxsUtilities/src/main/scala/org/dirac/axs/FrameFunctions.scala
@@ -20,10 +20,10 @@ object FrameFunctions {
       val ra2 = r2 / 180 * Math.PI
       val dec1 = d1 / 180 * Math.PI
       val dec2 = d2 / 180 * Math.PI
-      val ra = Math.min(Math.abs(ra1 - ra2), 360 - (Math.abs(ra1 - ra2)))
-      val dec = Math.min(Math.abs(dec1 - dec2), 360 - (Math.abs(dec1 - dec2)))
-      val cosdec = Math.cos(dec)
-      val cosc = Math.cos(ra) * cosdec
+      val ra = Math.min(Math.abs(ra1 - ra2), 2*Math.PI - (Math.abs(ra1 - ra2)))
+      val dec = Math.abs(dec1 - dec2)
+      val cosdec = Math.cos((dec1 + dec2)/2)
+      val cosc = Math.cos(ra) * Math.cos(dec)
       Math.sqrt(Math.pow(cosdec, 2) * Math.pow(Math.sin(ra), 2) +
         Math.pow(Math.sin(dec), 2)) / cosc
     }

--- a/AxsUtilities/src/main/scala/org/dirac/axs/FrameFunctions.scala
+++ b/AxsUtilities/src/main/scala/org/dirac/axs/FrameFunctions.scala
@@ -21,11 +21,12 @@ object FrameFunctions {
       val ra2 = r2 / 180 * Math.PI
       val dec1 = d1 / 180 * Math.PI
       val dec2 = d2 / 180 * Math.PI
-      val ra = Math.abs(ra1 - ra2)
-      val dec = Math.abs(dec1 - dec2)
       val cosdec = Math.cos((dec1 + dec2)/2)
-      val cosc = Math.cos(ra) * Math.cos(dec)
-      Math.sqrt(Math.pow(cosdec, 2) * Math.pow(Math.sin(ra), 2) +
+      val ra = Math.abs(ra1 - ra2)*cosdec
+      val dec = Math.abs(dec1 - dec2)
+      val cosdecdiff = Math.cos(dec)
+      val cosc = Math.cos(ra) * cosdecdiff
+      Math.sqrt(Math.pow(cosdecdiff, 2) * Math.pow(Math.sin(ra), 2) +
         Math.pow(Math.sin(dec), 2)) / cosc
     }
   }

--- a/AxsUtilities/src/main/scala/org/dirac/axs/FrameFunctions.scala
+++ b/AxsUtilities/src/main/scala/org/dirac/axs/FrameFunctions.scala
@@ -13,7 +13,7 @@ class FrameFunctions {
 
 object FrameFunctions {
   def calcGnom = (r1: Double, r2: Double, d1: Double, d2: Double, rcd1: Double, rcd2: Double) => {
-    val doNotCalc = (Math.abs(rcd1 - rcd2) > 1 && Math.abs(rcd1 - rcd2 - 360) > 1) || Math.abs(d1 - d2) > 1
+    val doNotCalc = (Math.abs(rcd1 - rcd2) > 1) || (Math.abs(d1 - d2) > 1)
     if (doNotCalc) {
       Double.MaxValue
     } else {
@@ -21,7 +21,7 @@ object FrameFunctions {
       val ra2 = r2 / 180 * Math.PI
       val dec1 = d1 / 180 * Math.PI
       val dec2 = d2 / 180 * Math.PI
-      val ra = Math.min(Math.abs(ra1 - ra2), 2*Math.PI - (Math.abs(ra1 - ra2)))
+      val ra = Math.abs(ra1 - ra2)
       val dec = Math.abs(dec1 - dec2)
       val cosdec = Math.cos((dec1 + dec2)/2)
       val cosc = Math.cos(ra) * Math.cos(dec)

--- a/AxsUtilities/src/main/scala/org/dirac/axs/FrameFunctions.scala
+++ b/AxsUtilities/src/main/scala/org/dirac/axs/FrameFunctions.scala
@@ -51,10 +51,12 @@ object FrameFunctions {
     val gnom_dist = degToGnom(r)
 
     val join = if (useSMJOptim)
-        df1.join(df2, df1("zone") === df2("zone") and (df1("ra") between(df2("ra") - r, df2("ra") + r)))
+        df1.join(df2, df1("zone") === df2("zone") and 
+                      (abs(df1("ra") - df2("ra"))*cos(radians((df1("dec")+df2("dec")/2))) < r))
       else
-        df1.join(df2, df1("zone") === df2("zone") and (df1("ra") between(df2("ra") - r, df2("ra") + r)) and
-          (df1("dec") between(df2("dec") - r, df2("dec") + r)))
+        df1.join(df2, df1("zone") === df2("zone") and
+                      (abs(df1("ra") - df2("ra"))*cos(radians((df1("dec")+df2("dec")/2))) < r) and
+                      (df1("dec") between(df2("dec") - r, df2("dec") + r)))
 
     var distcolname = "axsdist"
     if (returnMin) {

--- a/AxsUtilities/src/main/scala/org/dirac/axs/FrameFunctions.scala
+++ b/AxsUtilities/src/main/scala/org/dirac/axs/FrameFunctions.scala
@@ -5,6 +5,7 @@ package org.dirac.axs
 import org.apache.spark.sql.expressions.{UserDefinedFunction, Window}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{Column, DataFrame, Dataset, Row}
+import org.apache.spark.sql.functions.lit
 
 class FrameFunctions {
 
@@ -52,10 +53,12 @@ object FrameFunctions {
 
     val join = if (useSMJOptim)
         df1.join(df2, df1("zone") === df2("zone") and 
-                      (abs(df1("ra") - df2("ra"))*cos(radians((df1("dec")+df2("dec"))/2)) < r))
+                      (df1("ra") between(df2("ra") - lit(r)/cos(radians(df2("dec"))),
+                                         df2("ra") + lit(r)/cos(radians(df2("dec"))))))
       else
         df1.join(df2, df1("zone") === df2("zone") and
-                      (abs(df1("ra") - df2("ra"))*cos(radians((df1("dec")+df2("dec"))/2)) < r) and
+                      (df1("ra") between(df2("ra") - lit(r)/cos(radians(df2("dec"))),
+                                         df2("ra") + lit(r)/cos(radians(df2("dec"))))) and
                       (df1("dec") between(df2("dec") - r, df2("dec") + r)))
 
     var distcolname = "axsdist"

--- a/AxsUtilities/src/main/scala/org/dirac/axs/FrameFunctions.scala
+++ b/AxsUtilities/src/main/scala/org/dirac/axs/FrameFunctions.scala
@@ -13,7 +13,8 @@ class FrameFunctions {
 
 object FrameFunctions {
   def calcGnom = (r1: Double, r2: Double, d1: Double, d2: Double, rcd1: Double, rcd2: Double) => {
-    val doNotCalc = (Math.abs(rcd1 - rcd2) > 1) || (Math.abs(d1 - d2) > 1)
+    val cosdec = ((rcd1/r1) + (rcd2/r2))/2
+    val doNotCalc = (Math.abs(rcd1 - rcd2) > 0.2 && Math.abs(rcd1 - rcd2 - 360*cosdec) > 0.2) || (Math.abs(d1 - d2) > 0.2)
     if (doNotCalc) {
       Double.MaxValue
     } else {
@@ -21,8 +22,7 @@ object FrameFunctions {
       val ra2 = r2 / 180 * Math.PI
       val dec1 = d1 / 180 * Math.PI
       val dec2 = d2 / 180 * Math.PI
-      val cosdec = Math.cos((dec1 + dec2)/2)
-      val ra = Math.abs(ra1 - ra2)*cosdec
+      val ra = Math.min(Math.abs(ra1 - ra2)*cosdec, Math.abs(ra1 - ra2 - 2*Math.PI)*cosdec)
       val dec = Math.abs(dec1 - dec2)
       val cosdecdiff = Math.cos(dec)
       val cosc = Math.cos(ra) * cosdecdiff

--- a/AxsUtilities/src/main/scala/org/dirac/axs/FrameFunctions.scala
+++ b/AxsUtilities/src/main/scala/org/dirac/axs/FrameFunctions.scala
@@ -53,10 +53,10 @@ object FrameFunctions {
 
     val join = if (useSMJOptim)
         df1.join(df2, df1("zone") === df2("zone") and 
-                      (df1("racosdec") between(df2("axs_racosdec") - r, df2("axs_racosdec") + r)))
+                      (df1("racosdec") between(df2("racosdec") - r, df2("racosdec") + r)))
       else
         df1.join(df2, df1("zone") === df2("zone") and
-                      (df1("racosdec") between(df2("axs_racosdec") - r, df2("axs_racosdec") + r)) and
+                      (df1("racosdec") between(df2("racosdec") - r, df2("racosdec") + r)) and
                       (df1("dec") between(df2("dec") - r, df2("dec") + r)))
 
     var distcolname = "axsdist"

--- a/axs/axsframe.py
+++ b/axs/axsframe.py
@@ -310,20 +310,23 @@ class AxsFrame(DataFrame):
         step1 = rng1 / numbins1
         step2 = rng2 / numbins2
 
-        hist2d = res.withColumn("bin1", ((res[colname1]-min1)/step1).cast("int")*step1+min1) \
-            .withColumn("bin2", ((res[colname2]-min2)/step2).cast("int")*step2+min2).\
-            groupBy("bin1", "bin2").count()
+        hist2d = res.withColumn("bin1", ((res[colname1]-min1)/step1).cast("int")) \
+                    .withColumn("bin2", ((res[colname2]-min2)/step2).cast("int")) \
+                    .groupBy("bin1", "bin2").count()
         hist2data = hist2d.orderBy(hist2d.bin1, hist2d.bin2).collect()
-        bin1 = list(map(lambda row: row.bin1, hist2data))
-        bin2 = list(map(lambda row: row.bin2, hist2data))
-        vals = list(map(lambda row: row["count"], hist2data))
+        bin1 = np.array(list(map(lambda row: row.bin1, hist2data)))
+        bin2 = np.array(list(map(lambda row: row.bin2, hist2data)))
+        vals = np.array(list(map(lambda row: row["count"], hist2data)))
 
         x, y = np.mgrid[slice(min1, max1 + step1, step1),
                         slice(min2, max2 + step2, step2)]
-        z = np.zeros(x.shape)
-        for b1, b2, v in zip(bin1, bin2, vals):
-            z[int((b1-min1)/step1)][int((b2-min2)/step2)] = v
-        return x, y, z
+
+        z = np.zeros(numbins1*numbins2)
+        ok_bins = np.where((bin1 >= 0) & (bin1 < numbins1) & (bin2 >= 0) & (bin2 < numbins2))
+        bin_onedim_index = bin2 + bin1*numbins2
+        z[bin_onedim_index[ok_bins]] = vals[ok_bins]
+
+        return x, y, z.reshape((numbins1, numbins2))
 
     def exclude_duplicates(self):
         """

--- a/axs/catalog.py
+++ b/axs/catalog.py
@@ -1,4 +1,5 @@
 
+import numpy as np
 from axs.axsframe import AxsFrame
 from axs import Constants
 from pyspark.sql import functions as F
@@ -219,9 +220,9 @@ class AxsCatalog:
         return df.where(((df.dec + 90) > zone_height) & (
                 (df.dec + 90) % zone_height < AxsCatalog.NGBR_BORDER_HEIGHT)).\
                 withColumn("zone", ((df.dec + 90) / zone_height - 1).cast("long")). \
-                withColumn("dup", F.lit(1)).\
+                withColumn("dup", F.lit(1)).withColumn("racosdec", df.ra*np.cos(df.dec*np.pi/180)).\
             union(df.withColumn("zone", ((df.dec + 90) / zone_height).cast("long")).
-                withColumn("dup", F.lit(0)))
+                withColumn("dup", F.lit(0)).withColumn("racosdec", df.ra*np.cos(df.dec*np.pi/180)))
 
     def add_increment(self, table_name, increment_df, rename_to=None, temp_tbl_name=None):
         """

--- a/axs/catalog.py
+++ b/axs/catalog.py
@@ -228,7 +228,7 @@ class AxsCatalog:
                 withColumn("dup", F.lit(1)).
                 withColumn("racosdec", (F.col("ra") + 360)*F.cos(F.radians(F.col("dec")))).
                 withColumn("ra", df.ra + 360.0)).\
-            union(df.where(((360 - df.ra) > AxsCatalog.NGBR_BORDER_HEIGHT/F.cos(F.radians(F.col("dec")))) & (df.ra <= 360.0)).\
+            union(df.where(((360 - df.ra) < AxsCatalog.NGBR_BORDER_HEIGHT/F.cos(F.radians(F.col("dec")))) & (df.ra <= 360.0)).\
                 withColumn("zone",  ((df.dec +90) / zone_height).cast("long")).
                 withColumn("dup", F.lit(1)).
                 withColumn("racosdec", (F.col("ra") - 360)*F.cos(F.radians(F.col("dec")))).

--- a/axs/catalog.py
+++ b/axs/catalog.py
@@ -228,13 +228,13 @@ class AxsCatalog:
                 withColumn("dup", F.lit(1)).
                 withColumn("racosdec", (F.col("ra") + 360)*F.cos(F.radians(F.col("dec")))).
                 withColumn("ra", df.ra + 360.0)).\
-            union(df.where(((360 - df.ra) > AxsCatalog.NGBR_BORDER_HEIGHT/np.cos(np.radians(df.dec))) & (df.ra <= 360.0)).\
+            union(df.where(((360 - df.ra) > AxsCatalog.NGBR_BORDER_HEIGHT/F.cos(F.radians(F.col("dec")))) & (df.ra <= 360.0)).\
                 withColumn("zone",  ((df.dec +90) / zone_height).cast("long")).
                 withColumn("dup", F.lit(1)).
                 withColumn("racosdec", (F.col("ra") - 360)*F.cos(F.radians(F.col("dec")))).
                 withColumn("ra", df.ra - 360.0)).\
             union(df.withColumn("zone", ((df.dec + 90) / zone_height).cast("long")).
-                withColumn("dup", F.lit(0))
+                withColumn("dup", F.lit(0)))
 
     def add_increment(self, table_name, increment_df, rename_to=None, temp_tbl_name=None):
         """

--- a/axs/catalog.py
+++ b/axs/catalog.py
@@ -20,6 +20,7 @@ class AxsCatalog:
     DEC_COLNAME = "dec"
     DUP_COLNAME = "dup"
     ZONE_COLNAME = "zone"
+    RACOSDEC_COLNAME = "racosdec"
 
     NUM_BUCKETS = Constants.NUM_BUCKETS
 
@@ -216,6 +217,8 @@ class AxsCatalog:
                             "' column already exists.")
         if AxsCatalog.DUP_COLNAME in df.columns:
             raise Exception("Cannot save as AXS table: '"+AxsCatalog.DUP_COLNAME+"' column already exists")
+        if AxsCatalog.RACOSDEC_COLNAME in df.columns:
+            raise Exception("Cannot save as AXS table: '"+AxsCatalog.RACOSDEC_COLNAME+"' column already exists")
 
         df = df.withColumn("racosdec", F.col("ra")*F.cos(F.radians(F.col("dec"))))
 


### PR DESCRIPTION
This PR fixes the drop in crossmatching density near the celestial poles by applying the cosine of Declination following astronomy-commons/axs#22 and astronomy-commons/axs#23.

The fix for overflowing histogram2d from https://github.com/astronomy-commons/axs/commit/56248a1b2f8daff01d51d64a2516e2f0b634b553 has been included here as I wanted to test a subset of the sky near the celestial poles. 